### PR TITLE
Added Vue 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,28 @@ Forked from [react-div-100vh](https://github.com/mvasin/react-div-100vh) by [mva
 
 [ViewDemo vue-100vh](https://razumnyak.github.io/vue-div-100vh/)
 
+## Version map
+
+Vue 3 renamed `destroyed` to `unmounted`, which is backwards incompatible with
+Vue 2. The `package.json` has been updated to match this, but for reference,
+this is the compatibility table for `vue` : `vue-100vh`:
+
+| Vue version | `vue-100vh` version |
+| ----------- | ------------------- |
+| `^3.0`      | `^0.2.0`            |
+| `^2.6`      | `^0.1.0`            |
+
 
 ## Add in your Vue project
 
-> npm i vue-100vh
+```
+npm i vue-100vh
+```
 
 
 ## The default behavior
 
-```jsx
+```vue
 <template>
   <vue100vh :css="{height: '100rvh';}">
     <marquee>Your stuff goes here</marquee>
@@ -32,7 +45,8 @@ export default {
 ```
 
 ### Using `rvh` units
-```jsx
+
+```vue
   <vue100vh :style="{ minHeight: '50rvh' }">
     <marquee>This is inside a div that takes at least 50% of viewport height.</marquee>
   </vue100vh>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-100vh",
   "description": "A Vue component, which solves the 100vh problem in mobile browsers, fork from React component",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Vladimir Razumnyak <razumnyak.v@gmail.com>",
   "main": "src/vue100vh/index.js",
   "repository": {
@@ -13,13 +13,13 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "vue": "^2.6",
+    "vue": "^3.0",
     "jest-get-type": "^22.4.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.5.0",
-    "@vue/cli-service": "^3.5.0",
-    "vue-template-compiler": "^2.5.21"
+    "@vue/cli-service": "^4.5.8",
+    "@vue/compiler-sfc": "^3.0.2"
   },
   "postcss": {
     "plugins": {

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,8 @@
-import Vue from 'vue'
+import { createApp, h } from 'vue'
 import Demo from './demo/Demo.vue'
 import Vue100vh from './vue100vh'
 
-Vue.config.productionTip = false
-
-Vue.use(Vue100vh)
-
-Vue.component('Vue100vh', Vue100vh)
-
-new Vue({
-  render: h => h(Demo),
-}).$mount('#app')
+// Make Vue app
+createApp({ render: () => h(Demo) })
+    .component('Vue100vh', Vue100vh)
+    .mount('#app')

--- a/src/vue100vh/vue100vh.vue
+++ b/src/vue100vh/vue100vh.vue
@@ -7,7 +7,7 @@
 import convertStyle from './convertStyle/convertStyle'
 export default {
   name: 'vue100vh',
-  props:['css'],
+  props: ['css'],
   data () {
     return {
       objectStyle: {}
@@ -17,7 +17,7 @@ export default {
     this.updateStyle();
     window.addEventListener('resize', this.updateStyle);
   },
-  destroyed () {
+  unmounted () {
     window.removeEventListener('resize', this.updateStyle);
   },
   methods:{


### PR DESCRIPTION
Some changes to make this work with Vue 3:

- Renamed `destroyed` hook to `unmounted`
- Updated `main.js` to use the new `createApp` methods instead of the global `Vue` instance.
- Updated `README.md` to have a compatibility table